### PR TITLE
39 상한 계산

### DIFF
--- a/src/app/(route)/(home)/_components/CharacterInfoPanel.tsx
+++ b/src/app/(route)/(home)/_components/CharacterInfoPanel.tsx
@@ -1,20 +1,13 @@
 import Section from "@/app/_components/layout/Section";
 import Column from "@/app/_components/layout/Column";
-import Row from "@/app/_components/layout/Row";
-import UserSearch from "@/app/_components/home/characterInfoPanel/UserSearch";
+import AbilityRankHeader from "@/app/_components/home/characterInfoPanel/AbilityRankHeader";
 import AbilityRankList from "@/app/_components/home/characterInfoPanel/AbilityRankList";
-import ResetBtn from "@/app/_components/home/characterInfoPanel/Menu/ResetBtn";
-import StatDropDownMenu from "@/app/_components/home/characterInfoPanel/Menu/StatDropDownMenu";
 
 const CharacterInfoPanel = () => {
   return (
     <Section className="h-full w-full gap-1 text-xs text-gray-200">
       <Column className="flex h-full w-full gap-1">
-        <Row className="flex items-center justify-center gap-1">
-          <UserSearch />
-          <ResetBtn />
-          <StatDropDownMenu />
-        </Row>
+        <AbilityRankHeader />
         <Column className="h-full">
           <AbilityRankList />
         </Column>

--- a/src/app/_components/home/characterInfoPanel/AbilityRankHeader.tsx
+++ b/src/app/_components/home/characterInfoPanel/AbilityRankHeader.tsx
@@ -1,0 +1,18 @@
+import Row from "../../layout/Row";
+import RaidDropDownMenu from "./menu/RaidDropDownMenu";
+import ResetBtn from "./menu/ResetBtn";
+import StatDropDownMenu from "./menu/StatDropDownMenu";
+import UserSearch from "./UserSearch";
+
+const AbilityRankHeader = () => {
+  return (
+    <Row className="flex items-center justify-center gap-1">
+      <UserSearch />
+      <ResetBtn />
+      <StatDropDownMenu />
+      <RaidDropDownMenu />
+    </Row>
+  );
+};
+
+export default AbilityRankHeader;

--- a/src/app/_components/home/characterInfoPanel/AbilityRankHeader.tsx
+++ b/src/app/_components/home/characterInfoPanel/AbilityRankHeader.tsx
@@ -1,8 +1,8 @@
 import Row from "../../layout/Row";
-import RaidDropDownMenu from "./menu/RaidDropDownMenu";
-import ResetBtn from "./menu/ResetBtn";
-import StatDropDownMenu from "./menu/StatDropDownMenu";
 import UserSearch from "./UserSearch";
+import ResetBtn from "./menuList/ResetBtn";
+import StatDropDownMenu from "./menuList/StatDropDownMenu";
+import RaidDropDownMenu from "./menuList/RaidDropDownMenu";
 
 const AbilityRankHeader = () => {
   return (

--- a/src/app/_components/home/characterInfoPanel/AbilityRankTbody.tsx
+++ b/src/app/_components/home/characterInfoPanel/AbilityRankTbody.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import { useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
+
 import { useCharacterStore } from "@/app/_store/characterStore";
 import { useRankStore } from "@/app/_store/useRankStore";
 import { filterCharacters } from "./utils/filterCharacters";
 import { useDrag } from "@/app/_hooks/useDrag/useDrag";
-import { useEffect } from "react";
 import { getLocalStorageItems } from "@/app/_utils/localStorage";
 import { LOCALSTORAGE_KEY } from "@/app/_constant/localstorage";
 import { MergedCharacter } from "@/app/_type/characterType";
+import { useRaidStore } from "@/app/_store/raidStore";
+import LimitStat from "./stat/LimitStat";
 
 const AbilityRankTbody = () => {
   const characters = useCharacterStore((state) => state.characters);
@@ -25,6 +28,8 @@ const AbilityRankTbody = () => {
 
   const { dragEnd, dragEnter, dragOver, dragStart } =
     useDrag(setDropCharacterist);
+
+  const selectedBoss = useRaidStore((state) => state.selectedBoss);
 
   useEffect(() => {
     const waitinList =
@@ -50,10 +55,16 @@ const AbilityRankTbody = () => {
               className="flex h-full flex-1 items-center justify-center"
               key={i?.stat_name + i?.stat_value}
             >
-              <span>
-                {i?.stat_value}
-                <p className="text-center text-[10px] text-green-300">(+90)</p>
-              </span>
+              <div className="flex flex-col items-center justify-center">
+                <span>{i?.stat_value}</span>
+                {selectedBoss && (
+                  <LimitStat
+                    characterName={c.name}
+                    selectedBoss={selectedBoss}
+                    {...i}
+                  />
+                )}
+              </div>
             </td>
           ))}
         </tr>

--- a/src/app/_components/home/characterInfoPanel/AbilityRankTbody.tsx
+++ b/src/app/_components/home/characterInfoPanel/AbilityRankTbody.tsx
@@ -48,7 +48,7 @@ const AbilityRankTbody = () => {
           onDragEnd={dragEnd}
           onDragOver={dragOver}
           onDragEnter={() => dragEnter(i)}
-          className={`flex w-full grid-cols-9 items-center justify-center rounded-lg lg:grid ${c?.name?.length > 1 ? "border-b border-gray-400 hover:cursor-pointer hover:bg-zinc-600" : ""} ${selectedCharacter?.name === c.name && selectedCharacter?.name !== null ? "text-blue-300" : ""}`}
+          className={`flex w-full items-center justify-center rounded-lg ${c?.name?.length > 1 ? "border-b border-gray-400 hover:cursor-pointer hover:bg-zinc-600" : ""} ${selectedCharacter?.name === c.name && selectedCharacter?.name !== null ? "text-blue-300" : ""}`}
         >
           {c?.info.map((i) => (
             <td

--- a/src/app/_components/home/characterInfoPanel/AbilityRankThead.tsx
+++ b/src/app/_components/home/characterInfoPanel/AbilityRankThead.tsx
@@ -22,7 +22,7 @@ const AbilityRankThead = () => {
 
   return (
     <thead className="min-h-8 w-full items-center justify-center rounded-lg bg-zinc-800">
-      <tr className="relative flex h-full w-full grid-cols-9 lg:grid">
+      <tr className="relative flex h-full w-full items-center justify-center">
         {rankTitleList?.map(
           (t, i) =>
             t?.isView && (

--- a/src/app/_components/home/characterInfoPanel/Menu/RaidDropDownMenu.tsx
+++ b/src/app/_components/home/characterInfoPanel/Menu/RaidDropDownMenu.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useState } from "react";
+import Button from "@/app/_components/common/Button";
+import BottomArrow from "@/app/_components/common/BottomArrow";
+import { useOutsideClick } from "@/app/_hooks/useOutsideClick/useOutsideClick";
+import { raidList } from "@/app/_constant/raidList";
+import { useRaidStore } from "@/app/_store/raidStore";
+
+const RaidDropDownMenu = () => {
+  const [view, setView] = useState(false);
+  const [activeRaid, setActiveRaid] = useState<string | null>(null);
+
+  const setSelectBoss = useRaidStore((state) => state.setSelectBoss);
+  // const raidName = useRaidStore((state) => state.raidName);
+  // const setRaidName = useRaidStore((state) => state.setRaidName);
+  const selectedBoss = useRaidStore((state) => state.selectedBoss);
+  const resetRaid = useRaidStore((state) => state.resetRaid);
+
+  const dropdownRef = useOutsideClick(() => {
+    setView(false);
+    // setActiveRaid(null); // 메뉴 닫힐 때 서브 메뉴도 닫기
+  });
+
+  const raidOnclick = (raidName: string) => {
+    if (activeRaid === raidName) {
+      setView(false);
+      setActiveRaid(null);
+      resetRaid();
+      return;
+    }
+    setActiveRaid(raidName);
+    // setActiveRaid((prev) => (prev === raidName ? null : raidName));
+  };
+
+  return (
+    <div className="inline-block h-full w-32" ref={dropdownRef}>
+      <Button
+        onClick={() => setView((pre) => !pre)}
+        className="flex h-full w-full items-center justify-center"
+      >
+        <span>{selectedBoss?.name || "상한 확인"}</span>
+        <BottomArrow />
+      </Button>
+      <div
+        className={`absolute z-10 mt-1 flex w-32 flex-col rounded-lg bg-black transition-all duration-300 ease-in-out ${
+          view
+            ? "translate-y-0 opacity-100"
+            : "pointer-events-none translate-y-[10px] opacity-0"
+        } `}
+      >
+        <div className="flex h-full w-full flex-col">
+          {raidList.map((r) => (
+            <div key={r.raid_name} className="relative">
+              <button
+                onClick={() => raidOnclick(r.raid_name)}
+                className={`h-8 w-full ${activeRaid === r.raid_name ? "text-blue-300" : ""} hover:bg-zinc-700`}
+              >
+                {r.raid_name}
+              </button>
+              {/* 하위 메뉴: 몬스터 이름 렌더링 */}
+              {activeRaid === r.raid_name && (
+                <div className="absolute left-32 top-0 z-20 w-28 bg-black">
+                  {r.monsters.map((monster) => (
+                    <button
+                      onClick={() => setSelectBoss(r?.raid_name, monster?.name)}
+                      key={monster.name}
+                      className={`${selectedBoss?.name === monster?.name ? "text-blue-300" : "text-white"} h-8 w-full hover:bg-zinc-700`}
+                    >
+                      {monster.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RaidDropDownMenu;

--- a/src/app/_components/home/characterInfoPanel/Menu/ResetBtn.tsx
+++ b/src/app/_components/home/characterInfoPanel/Menu/ResetBtn.tsx
@@ -1,12 +1,17 @@
 "use client";
+import { CiTrash } from "react-icons/ci";
+
 import Button from "@/app/_components/common/Button";
 import { useCharacterStore } from "@/app/_store/characterStore";
 
 const ResetBtn = () => {
   const reset = useCharacterStore((state) => state.reset);
   return (
-    <Button className="h-full w-12" onClick={reset}>
-      리셋
+    <Button
+      className="flex h-full w-12 items-center justify-center"
+      onClick={reset}
+    >
+      <CiTrash className="text-xl" />
     </Button>
   );
 };

--- a/src/app/_components/home/characterInfoPanel/Menu/StatDropDownMenu.tsx
+++ b/src/app/_components/home/characterInfoPanel/Menu/StatDropDownMenu.tsx
@@ -5,18 +5,23 @@ import { useRankStore } from "@/app/_store/useRankStore";
 import { useDrag } from "@/app/_hooks/useDrag/useDrag";
 import Button from "@/app/_components/common/Button";
 import BottomArrow from "@/app/_components/common/BottomArrow";
+import { useOutsideClick } from "@/app/_hooks/useOutsideClick/useOutsideClick";
 
 const StatDropDownMenu = () => {
-  const [view, isView] = useState(false);
+  const [view, setView] = useState(false);
   const rankTitleList = useRankStore((state) => state.rankTitleList);
   const toggleView = useRankStore((state) => state.toggleView);
   const setDropTitleList = useRankStore((state) => state.setDropTitleList);
   const { dragEnd, dragEnter, dragOver, dragStart } = useDrag(setDropTitleList);
 
+  const dropdownRef = useOutsideClick(() => {
+    setView(false);
+  });
+
   return (
-    <div className="inline-block h-full w-24">
+    <div className="inline-block h-full w-24" ref={dropdownRef}>
       <Button
-        onClick={() => isView((pre) => !pre)}
+        onClick={() => setView((pre) => !pre)}
         className="flex h-full w-full items-center justify-center"
       >
         <span>스텟 추가</span>
@@ -34,7 +39,7 @@ const StatDropDownMenu = () => {
             onDragOver={dragOver}
             onDragEnter={() => dragEnter(i)}
             onDragEnd={() => dragEnd()}
-            className={`h-8 hover:bg-zinc-700 ${t.isView === true ? "text-blue-300" : "text-red-300"}`}
+            className={`h-8 rounded-lg hover:bg-zinc-700 ${t.isView === true ? "text-blue-300" : "text-red-300"}`}
           >
             {t.stat_name}
           </button>

--- a/src/app/_components/home/characterInfoPanel/UserSearch.tsx
+++ b/src/app/_components/home/characterInfoPanel/UserSearch.tsx
@@ -7,7 +7,6 @@ import Row from "../../layout/Row";
 import Input from "../../common/Input";
 import Loading from "../../common/Loading";
 import Button from "../../common/Button";
-
 import { useCharacterStore } from "@/app/_store/characterStore";
 import { useCharacter } from "@/app/_hooks/useCharacter/useCharacter";
 
@@ -48,10 +47,10 @@ const UserSearch = () => {
         <Button
           type="submit"
           disabled={loading}
-          className={`h-full w-14 text-xs ${loading ? "opacity-80" : ""}`}
+          className={`h-full w-16 text-xs ${loading ? "opacity-80" : ""}`}
           onClick={onClickHandler}
         >
-          {!loading ? "검색" : <Loading />}
+          {!loading ? <span>검색</span> : <Loading />}
         </Button>
       </form>
     </Row>

--- a/src/app/_components/home/characterInfoPanel/stat/LimitStat.tsx
+++ b/src/app/_components/home/characterInfoPanel/stat/LimitStat.tsx
@@ -1,0 +1,46 @@
+import { MonstersType } from "@/app/_constant/raidList";
+import { limitCalculator } from "../utils/limitCalculator";
+import { useRankStore } from "@/app/_store/useRankStore";
+import { useCharacterStore } from "@/app/_store/characterStore";
+
+const LimitStat = (props: {
+  selectedBoss: MonstersType;
+  stat_name: string;
+  stat_value: string;
+  characterName: string;
+}) => {
+  const selectedBoss = props.selectedBoss;
+  const statName = props.stat_name;
+  const statValue = props.stat_value;
+  const characterName = props.characterName;
+
+  const rankTitleList = useRankStore((state) => state?.rankTitleList);
+  const isLimit = rankTitleList.find((t) => t.stat_name === "해제")?.isView;
+
+  const limitValue = useCharacterStore((state) => {
+    if (isLimit) {
+      return (
+        state?.characters
+          .find((c) => c?.name === characterName)
+          ?.stat.find((i) => i.stat_name === "해제")?.stat_value ?? "0"
+      );
+    }
+    return "0";
+  });
+
+  const stat = limitCalculator(selectedBoss, statName, statValue, limitValue);
+
+  return (
+    <>
+      {stat !== undefined && (
+        <span
+          className={`block text-center text-[10px] ${Number(stat) >= 0 ? "text-green-300" : "text-red-300"} `}
+        >
+          {stat !== null && stat >= 0 ? `+${stat}` : stat}
+        </span>
+      )}
+    </>
+  );
+};
+
+export default LimitStat;

--- a/src/app/_components/home/characterInfoPanel/utils/limitCalculator.ts
+++ b/src/app/_components/home/characterInfoPanel/utils/limitCalculator.ts
@@ -1,0 +1,39 @@
+import { MonstersType } from "@/app/_constant/raidList";
+
+export const limitCalculator = (
+  monsterInfo: MonstersType,
+  user_stat_name: string,
+  user_stat_value: string,
+  user_limit_stat?: string | null,
+) => {
+  switch (user_stat_name) {
+    case "공격력": {
+      const Mstat = monsterInfo?.limit?.find((s) => s?.stat_name === "공격력");
+      const limit = user_limit_stat !== null ? Number(user_limit_stat) : 0;
+      // 해제가 존재한다면 MStat은 해당 캐릭터의 해제가 포함된 값이어야함
+      return Number(user_stat_value) - (Number(Mstat?.stat_value) + limit);
+    }
+
+    case "크리티컬": {
+      const Mstat = monsterInfo?.limit?.find(
+        (s) => s?.stat_name === "크리티컬 저항",
+      );
+      return Number(user_stat_value) - (Number(Mstat?.stat_value) + 50);
+    }
+    case "밸런스": {
+      const Mstat = monsterInfo?.limit?.find(
+        (s) => s?.stat_name === "밸런스 저항",
+      );
+      return Number(user_stat_value) - (Number(Mstat?.stat_value) + 100);
+    }
+    case "대항력": {
+      const Mstat = monsterInfo?.limit?.find(
+        (s) => s?.stat_name === "대항력 저항",
+      );
+      return Number(user_stat_value) - (Number(Mstat?.stat_value) + 100);
+    }
+
+    default:
+      return null;
+  }
+};

--- a/src/app/_constant/raidList.ts
+++ b/src/app/_constant/raidList.ts
@@ -1,0 +1,624 @@
+export interface MonstersType {
+  name: string;
+  limit: { stat_name: string; stat_value: string }[];
+}
+
+export interface RaidListType {
+  raid_name: string;
+  monsters: MonstersType[];
+}
+
+export const raidList: RaidListType[] = [
+  {
+    raid_name: "아르드리",
+    monsters: [
+      {
+        name: "왕성 토파즈 홀",
+        limit: [
+          { stat_name: "이름", stat_value: "로메르" },
+          { stat_name: "레벨", stat_value: "110" },
+          { stat_name: "공격력", stat_value: "42300" },
+          { stat_name: "크리티컬", stat_value: "215" },
+          { stat_name: "크리티컬 저항", stat_value: "175" },
+          { stat_name: "대항력 저항", stat_value: "88" },
+          { stat_name: "밸런스 저항", stat_value: "7" },
+        ],
+      },
+      {
+        name: "잊혀진 제단",
+        limit: [
+          { stat_name: "이름", stat_value: "나베리우스" },
+          { stat_name: "레벨", stat_value: "110" },
+          { stat_name: "공격력", stat_value: "44110" },
+          { stat_name: "크리티컬", stat_value: "223" },
+          { stat_name: "크리티컬 저항", stat_value: "181" },
+          { stat_name: "대항력 저항", stat_value: "92" },
+          { stat_name: "밸런스 저항", stat_value: "9" },
+        ],
+      },
+      {
+        name: "죽음의 변증법",
+        limit: [
+          { stat_name: "이름", stat_value: "밀레드" },
+          { stat_name: "레벨", stat_value: "110" },
+          { stat_name: "공격력", stat_value: "45920" },
+          { stat_name: "크리티컬", stat_value: "231" },
+          { stat_name: "크리티컬 저항", stat_value: "188" },
+          { stat_name: "대항력 저항", stat_value: "100" },
+          { stat_name: "밸런스 저항", stat_value: "12" },
+        ],
+      },
+      {
+        name: "원한의 암굴",
+        limit: [
+          { stat_name: "이름", stat_value: "카사르" },
+          { stat_name: "레벨", stat_value: "110" },
+          { stat_name: "공격력", stat_value: "47780" },
+          { stat_name: "크리티컬", stat_value: "240" },
+          { stat_name: "크리티컬 저항", stat_value: "195" },
+          { stat_name: "대항력 저항", stat_value: "108" },
+          { stat_name: "밸런스 저항", stat_value: "14" },
+        ],
+      },
+      {
+        name: "위대한 사역",
+        limit: [
+          { stat_name: "이름", stat_value: "에녹" },
+          { stat_name: "레벨", stat_value: "110" },
+          { stat_name: "공격력", stat_value: "47780" },
+          { stat_name: "크리티컬", stat_value: "248" },
+          { stat_name: "크리티컬 저항", stat_value: "204" },
+          { stat_name: "대항력 저항", stat_value: "116" },
+          { stat_name: "밸런스 저항", stat_value: "16" },
+        ],
+      },
+    ],
+  },
+
+  {
+    raid_name: "오르나",
+    monsters: [
+      {
+        name: "로흘란의 바람",
+        limit: [
+          { stat_name: "이름", stat_value: "이루산" },
+          { stat_name: "레벨", stat_value: "115" },
+          { stat_name: "공격력", stat_value: "48780" },
+          { stat_name: "크리티컬", stat_value: "262" },
+          { stat_name: "크리티컬 저항", stat_value: "206" },
+          { stat_name: "대항력 저항", stat_value: "116" },
+          { stat_name: "밸런스 저항", stat_value: "20" },
+        ],
+      },
+      {
+        name: "창조와 파괴의 성소",
+        limit: [
+          { stat_name: "이름", stat_value: "에메트" },
+          { stat_name: "레벨", stat_value: "115" },
+          { stat_name: "공격력", stat_value: "50180" },
+          { stat_name: "크리티컬", stat_value: "270" },
+          { stat_name: "크리티컬 저항", stat_value: "214" },
+          { stat_name: "대항력 저항", stat_value: "116" },
+          { stat_name: "밸런스 저항", stat_value: "28" },
+        ],
+      },
+
+      {
+        name: "검의 무덤",
+        limit: [
+          { stat_name: "이름", stat_value: "야르니르" },
+          { stat_name: "레벨", stat_value: "115" },
+          { stat_name: "공격력", stat_value: "52330" },
+          { stat_name: "크리티컬", stat_value: "279" },
+          { stat_name: "크리티컬 저항", stat_value: "226" },
+          { stat_name: "대항력 저항", stat_value: "136" },
+          { stat_name: "밸런스 저항", stat_value: "37" },
+        ],
+      },
+      {
+        name: "시드 별궁",
+        limit: [
+          { stat_name: "이름", stat_value: "브레스" },
+          { stat_name: "레벨", stat_value: "115" },
+          { stat_name: "공격력", stat_value: "53860" },
+          { stat_name: "크리티컬", stat_value: "288" },
+          { stat_name: "크리티컬 저항", stat_value: "240" },
+          { stat_name: "대항력 저항", stat_value: "156" },
+          { stat_name: "밸런스 저항", stat_value: "44" },
+        ],
+      },
+    ],
+  },
+
+  {
+    raid_name: "와드네",
+    monsters: [
+      {
+        name: "제단을 지키는 자",
+        limit: [
+          { stat_name: "이름", stat_value: "스렝" },
+          { stat_name: "레벨", stat_value: "120" },
+          { stat_name: "공격력", stat_value: "53920" },
+          { stat_name: "크리티컬", stat_value: "298" },
+          { stat_name: "크리티컬 저항", stat_value: "246" },
+          { stat_name: "대항력 저항", stat_value: "186" },
+          { stat_name: "밸런스 저항", stat_value: "53" },
+        ],
+      },
+      {
+        name: "그릇된 고해",
+        limit: [
+          { stat_name: "이름", stat_value: "스피노스" },
+          { stat_name: "레벨", stat_value: "120" },
+          { stat_name: "공격력", stat_value: "55920" },
+          { stat_name: "크리티컬", stat_value: "315" },
+          { stat_name: "크리티컬 저항", stat_value: "261" },
+          { stat_name: "대항력 저항", stat_value: "196" },
+          { stat_name: "밸런스 저항", stat_value: "56" },
+        ],
+      },
+    ],
+  },
+
+  {
+    raid_name: "스페셜 전투",
+    monsters: [
+      {
+        name: "스페셜 전투",
+        limit: [
+          { stat_name: "이름", stat_value: "스페셜 전투" },
+          { stat_name: "레벨", stat_value: "120" },
+          { stat_name: "공격력", stat_value: "53920" },
+          { stat_name: "크리티컬", stat_value: "298" },
+          { stat_name: "크리티컬 저항", stat_value: "246" },
+          { stat_name: "대항력 저항", stat_value: "186" },
+          { stat_name: "밸런스 저항", stat_value: "53" },
+        ],
+      },
+    ],
+  },
+
+  {
+    raid_name: "시공간 왜곡",
+    monsters: [
+      {
+        name: "찬탈자의 성채",
+        limit: [
+          { stat_name: "이름", stat_value: "혼의 찬탈자 타로스" },
+          { stat_name: "레벨", stat_value: "110" },
+          { stat_name: "공격력", stat_value: "50000" },
+          { stat_name: "크리티컬", stat_value: "290" },
+          { stat_name: "크리티컬 저항", stat_value: "229" },
+          { stat_name: "대항력 저항", stat_value: "180" },
+          { stat_name: "밸런스 저항", stat_value: "34" },
+        ],
+      },
+      {
+        name: "몰락한 기사의 전당",
+        limit: [
+          { stat_name: "이름", stat_value: "몰락자 아이젠리터" },
+          { stat_name: "레벨", stat_value: "115" },
+          { stat_name: "공격력", stat_value: "52850" },
+          { stat_name: "크리티컬", stat_value: "320" },
+          { stat_name: "크리티컬 저항", stat_value: "254" },
+          { stat_name: "대항력 저항", stat_value: "220" },
+          { stat_name: "밸런스 저항", stat_value: "59" },
+        ],
+      },
+    ],
+  },
+
+  {
+    raid_name: "결사대",
+    monsters: [
+      {
+        name: "사념의 바다",
+        limit: [
+          { stat_name: "이름", stat_value: "네반" },
+          { stat_name: "레벨", stat_value: "90" },
+          { stat_name: "공격력", stat_value: "27000" },
+          { stat_name: "크리티컬", stat_value: "125" },
+          { stat_name: "크리티컬 저항", stat_value: "90" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "0" },
+        ],
+      },
+      {
+        name: "달의 이면",
+        limit: [
+          { stat_name: "이름", stat_value: "발로르" },
+          { stat_name: "레벨", stat_value: "95" },
+          { stat_name: "공격력", stat_value: "33500" },
+          { stat_name: "크리티컬", stat_value: "150" },
+          { stat_name: "크리티컬 저항", stat_value: "123" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "0" },
+        ],
+      },
+      {
+        name: "모루 위의 검",
+        limit: [
+          { stat_name: "이름", stat_value: "브리지트" },
+          { stat_name: "레벨", stat_value: "100" },
+          { stat_name: "공격력", stat_value: "40000" },
+          { stat_name: "크리티컬", stat_value: "200" },
+          { stat_name: "크리티컬 저항", stat_value: "150" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "0" },
+        ],
+      },
+      {
+        name: "생명의 나무",
+        limit: [
+          { stat_name: "이름", stat_value: "라우라" },
+          { stat_name: "레벨", stat_value: "100" },
+          { stat_name: "공격력", stat_value: "45500" },
+          { stat_name: "크리티컬", stat_value: "235" },
+          { stat_name: "크리티컬 저항", stat_value: "185" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "4" },
+        ],
+      },
+    ],
+  },
+
+  {
+    raid_name: "결사대 [헬]",
+    monsters: [
+      {
+        name: "사념의 바다",
+        limit: [
+          { stat_name: "이름", stat_value: "네반" },
+          { stat_name: "레벨", stat_value: "90" },
+          { stat_name: "공격력", stat_value: "39000" },
+          { stat_name: "크리티컬", stat_value: "185" },
+          { stat_name: "크리티컬 저항", stat_value: "145" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "0" },
+        ],
+      },
+      {
+        name: "달의 이면",
+        limit: [
+          { stat_name: "이름", stat_value: "발로르" },
+          { stat_name: "레벨", stat_value: "100" },
+          { stat_name: "공격력", stat_value: "39000" },
+          { stat_name: "크리티컬", stat_value: "185" },
+          { stat_name: "크리티컬 저항", stat_value: "145" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "0" },
+        ],
+      },
+      {
+        name: "모루 위의 검",
+        limit: [
+          { stat_name: "이름", stat_value: "브리지트" },
+          { stat_name: "레벨", stat_value: "100" },
+          { stat_name: "공격력", stat_value: "45500" },
+          { stat_name: "크리티컬", stat_value: "225" },
+          { stat_name: "크리티컬 저항", stat_value: "185" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "0" },
+        ],
+      },
+      {
+        name: "생명의 나무",
+        limit: [
+          { stat_name: "이름", stat_value: "라우라" },
+          { stat_name: "레벨", stat_value: "105" },
+          { stat_name: "공격력", stat_value: "47280" },
+          { stat_name: "크리티컬", stat_value: "249" },
+          { stat_name: "크리티컬 저항", stat_value: "206" },
+          { stat_name: "대항력 저항", stat_value: "0" },
+          { stat_name: "밸런스 저항", stat_value: "17" },
+        ],
+      },
+    ],
+  },
+];
+
+const 아르드리 = {
+  raid_name: "아르드리",
+  monster: [
+    {
+      name: "왕성 토파즈 홀",
+      limit: [
+        { stat_name: "이름", stat_value: "로메르" },
+        { stat_name: "레벨", stat_value: "110" },
+        { stat_name: "공격력", stat_value: "42300" },
+        { stat_name: "크리티컬", stat_value: "215" },
+        { stat_name: "크리티컬 저항", stat_value: "175" },
+        { stat_name: "대항력 저항", stat_value: "88" },
+        { stat_name: "밸런스 저항", stat_value: "7" },
+      ],
+    },
+    {
+      name: "잊혀진 제단",
+      limit: [
+        { stat_name: "이름", stat_value: "나베리우스" },
+        { stat_name: "레벨", stat_value: "110" },
+        { stat_name: "공격력", stat_value: "44110" },
+        { stat_name: "크리티컬", stat_value: "223" },
+        { stat_name: "크리티컬 저항", stat_value: "181" },
+        { stat_name: "대항력 저항", stat_value: "92" },
+        { stat_name: "밸런스 저항", stat_value: "9" },
+      ],
+    },
+    {
+      name: "죽음의 변증법",
+      limit: [
+        { stat_name: "이름", stat_value: "밀레드" },
+        { stat_name: "레벨", stat_value: "110" },
+        { stat_name: "공격력", stat_value: "45920" },
+        { stat_name: "크리티컬", stat_value: "231" },
+        { stat_name: "크리티컬 저항", stat_value: "188" },
+        { stat_name: "대항력 저항", stat_value: "100" },
+        { stat_name: "밸런스 저항", stat_value: "12" },
+      ],
+    },
+    {
+      name: "원한의 암굴",
+      limit: [
+        { stat_name: "이름", stat_value: "카사르" },
+        { stat_name: "레벨", stat_value: "110" },
+        { stat_name: "공격력", stat_value: "47780" },
+        { stat_name: "크리티컬", stat_value: "240" },
+        { stat_name: "크리티컬 저항", stat_value: "195" },
+        { stat_name: "대항력 저항", stat_value: "108" },
+        { stat_name: "밸런스 저항", stat_value: "14" },
+      ],
+    },
+    {
+      name: "위대한 사역",
+      limit: [
+        { stat_name: "이름", stat_value: "에녹" },
+        { stat_name: "레벨", stat_value: "110" },
+        { stat_name: "공격력", stat_value: "47780" },
+        { stat_name: "크리티컬", stat_value: "248" },
+        { stat_name: "크리티컬 저항", stat_value: "204" },
+        { stat_name: "대항력 저항", stat_value: "116" },
+        { stat_name: "밸런스 저항", stat_value: "16" },
+      ],
+    },
+  ],
+};
+
+const 오르나 = {
+  raid_name: "오르나",
+  monsters: [
+    {
+      name: "창조와 파괴의 성소",
+      limit: [
+        { stat_name: "이름", stat_value: "에메트" },
+        { stat_name: "레벨", stat_value: "115" },
+        { stat_name: "공격력", stat_value: "50180" },
+        { stat_name: "크리티컬", stat_value: "270" },
+        { stat_name: "크리티컬 저항", stat_value: "214" },
+        { stat_name: "대항력 저항", stat_value: "116" },
+        { stat_name: "밸런스 저항", stat_value: "28" },
+      ],
+    },
+    {
+      name: "로흘란의 바람",
+      limit: [
+        { stat_name: "이름", stat_value: "이루산" },
+        { stat_name: "레벨", stat_value: "115" },
+        { stat_name: "공격력", stat_value: "48780" },
+        { stat_name: "크리티컬", stat_value: "262" },
+        { stat_name: "크리티컬 저항", stat_value: "206" },
+        { stat_name: "대항력 저항", stat_value: "116" },
+        { stat_name: "밸런스 저항", stat_value: "20" },
+      ],
+    },
+    {
+      name: "검의 무덤",
+      limit: [
+        { stat_name: "이름", stat_value: "야르니르" },
+        { stat_name: "레벨", stat_value: "115" },
+        { stat_name: "공격력", stat_value: "52330" },
+        { stat_name: "크리티컬", stat_value: "279" },
+        { stat_name: "크리티컬 저항", stat_value: "226" },
+        { stat_name: "대항력 저항", stat_value: "136" },
+        { stat_name: "밸런스 저항", stat_value: "37" },
+      ],
+    },
+    {
+      name: "시드 별궁",
+      limit: [
+        { stat_name: "이름", stat_value: "브레스" },
+        { stat_name: "레벨", stat_value: "115" },
+        { stat_name: "공격력", stat_value: "53860" },
+        { stat_name: "크리티컬", stat_value: "288" },
+        { stat_name: "크리티컬 저항", stat_value: "240" },
+        { stat_name: "대항력 저항", stat_value: "156" },
+        { stat_name: "밸런스 저항", stat_value: "44" },
+      ],
+    },
+  ],
+};
+
+const 와드네 = {
+  raid_name: "와드네",
+  monsters: [
+    {
+      name: "제단을 지키는 자",
+      limit: [
+        { stat_name: "이름", stat_value: "스렝" },
+        { stat_name: "레벨", stat_value: "120" },
+        { stat_name: "공격력", stat_value: "53920" },
+        { stat_name: "크리티컬", stat_value: "298" },
+        { stat_name: "크리티컬 저항", stat_value: "246" },
+        { stat_name: "대항력 저항", stat_value: "186" },
+        { stat_name: "밸런스 저항", stat_value: "53" },
+      ],
+    },
+    {
+      name: "그릇된 고해",
+      limit: [
+        { stat_name: "이름", stat_value: "스피노스" },
+        { stat_name: "레벨", stat_value: "120" },
+        { stat_name: "공격력", stat_value: "55920" },
+        { stat_name: "크리티컬", stat_value: "315" },
+        { stat_name: "크리티컬 저항", stat_value: "261" },
+        { stat_name: "대항력 저항", stat_value: "196" },
+        { stat_name: "밸런스 저항", stat_value: "56" },
+      ],
+    },
+  ],
+};
+
+const 스페셜전투 = {
+  raid_name: "스페셜 전투",
+  monsters: [
+    {
+      name: "스페셜 전투",
+      limit: [
+        { stat_name: "이름", stat_value: "스페셜 전투" },
+        { stat_name: "레벨", stat_value: "120" },
+        { stat_name: "공격력", stat_value: "53920" },
+        { stat_name: "크리티컬", stat_value: "298" },
+        { stat_name: "크리티컬 저항", stat_value: "246" },
+        { stat_name: "대항력 저항", stat_value: "186" },
+        { stat_name: "밸런스 저항", stat_value: "53" },
+      ],
+    },
+  ],
+};
+
+const 시공간왜곡 = {
+  raid_name: "시공간 왜곡",
+  monsters: [
+    {
+      name: "스페셜 전투",
+      limit: [
+        { stat_name: "이름", stat_value: "혼의 찬탈자 타로스" },
+        { stat_name: "레벨", stat_value: "110" },
+        { stat_name: "공격력", stat_value: "50000" },
+        { stat_name: "크리티컬", stat_value: "290" },
+        { stat_name: "크리티컬 저항", stat_value: "229" },
+        { stat_name: "대항력 저항", stat_value: "180" },
+        { stat_name: "밸런스 저항", stat_value: "34" },
+      ],
+    },
+    {
+      name: "몰락한 기사의 전당",
+      limit: [
+        { stat_name: "이름", stat_value: "몰락자 아이젠리터" },
+        { stat_name: "레벨", stat_value: "115" },
+        { stat_name: "공격력", stat_value: "52850" },
+        { stat_name: "크리티컬", stat_value: "320" },
+        { stat_name: "크리티컬 저항", stat_value: "254" },
+        { stat_name: "대항력 저항", stat_value: "220" },
+        { stat_name: "밸런스 저항", stat_value: "59" },
+      ],
+    },
+  ],
+};
+
+const 결사대 = {
+  raid_name: "결사대",
+  monsters: [
+    {
+      name: "사념의 바다",
+      limit: [
+        { stat_name: "이름", stat_value: "네반" },
+        { stat_name: "레벨", stat_value: "90" },
+        { stat_name: "공격력", stat_value: "27000" },
+        { stat_name: "크리티컬", stat_value: "125" },
+        { stat_name: "크리티컬 저항", stat_value: "90" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "0" },
+      ],
+    },
+    {
+      name: "달의 이면",
+      limit: [
+        { stat_name: "이름", stat_value: "발로르" },
+        { stat_name: "레벨", stat_value: "95" },
+        { stat_name: "공격력", stat_value: "33500" },
+        { stat_name: "크리티컬", stat_value: "150" },
+        { stat_name: "크리티컬 저항", stat_value: "123" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "0" },
+      ],
+    },
+    {
+      name: "모루 위의 검",
+      limit: [
+        { stat_name: "이름", stat_value: "브리지트" },
+        { stat_name: "레벨", stat_value: "100" },
+        { stat_name: "공격력", stat_value: "40000" },
+        { stat_name: "크리티컬", stat_value: "200" },
+        { stat_name: "크리티컬 저항", stat_value: "150" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "0" },
+      ],
+    },
+    {
+      name: "생명의 나무",
+      limit: [
+        { stat_name: "이름", stat_value: "라우라" },
+        { stat_name: "레벨", stat_value: "100" },
+        { stat_name: "공격력", stat_value: "45500" },
+        { stat_name: "크리티컬", stat_value: "235" },
+        { stat_name: "크리티컬 저항", stat_value: "185" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "4" },
+      ],
+    },
+  ],
+};
+
+const 헬결사대 = {
+  raid_name: "헬 결사대",
+  monsters: [
+    {
+      name: "사념의 바다",
+      limit: [
+        { stat_name: "이름", stat_value: "네반" },
+        { stat_name: "레벨", stat_value: "90" },
+        { stat_name: "공격력", stat_value: "39000" },
+        { stat_name: "크리티컬", stat_value: "185" },
+        { stat_name: "크리티컬 저항", stat_value: "145" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "0" },
+      ],
+    },
+    {
+      name: "달의 이면",
+      limit: [
+        { stat_name: "이름", stat_value: "발로르" },
+        { stat_name: "레벨", stat_value: "100" },
+        { stat_name: "공격력", stat_value: "39000" },
+        { stat_name: "크리티컬", stat_value: "185" },
+        { stat_name: "크리티컬 저항", stat_value: "145" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "0" },
+      ],
+    },
+    {
+      name: "모루 위의 검",
+      limit: [
+        { stat_name: "이름", stat_value: "브리지트" },
+        { stat_name: "레벨", stat_value: "100" },
+        { stat_name: "공격력", stat_value: "45500" },
+        { stat_name: "크리티컬", stat_value: "225" },
+        { stat_name: "크리티컬 저항", stat_value: "185" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "0" },
+      ],
+    },
+    {
+      name: "생명의 나무",
+      limit: [
+        { stat_name: "이름", stat_value: "라우라" },
+        { stat_name: "레벨", stat_value: "105" },
+        { stat_name: "공격력", stat_value: "47280" },
+        { stat_name: "크리티컬", stat_value: "249" },
+        { stat_name: "크리티컬 저항", stat_value: "206" },
+        { stat_name: "대항력 저항", stat_value: "0" },
+        { stat_name: "밸런스 저항", stat_value: "17" },
+      ],
+    },
+  ],
+};

--- a/src/app/_hooks/useOutsideClick/useOutsideClick.ts
+++ b/src/app/_hooks/useOutsideClick/useOutsideClick.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef, RefObject } from "react";
+
+export const useOutsideClick = (
+  callback: () => void,
+): RefObject<HTMLDivElement> => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [callback]);
+
+  return ref;
+};

--- a/src/app/_store/characterStore.ts
+++ b/src/app/_store/characterStore.ts
@@ -1,11 +1,6 @@
 import { create } from "zustand";
 import { MergedCharacter } from "../_type/characterType";
-import { c1 } from "../_constant/qwer";
-import {
-  getLocalStorageItems,
-  removeWatingRoomCharactersInfo,
-} from "../_utils/localStorage";
-import { LOCALSTORAGE_KEY } from "../_constant/localstorage";
+import { removeWatingRoomCharactersInfo } from "../_utils/localStorage";
 
 type State = {
   characters: MergedCharacter[];

--- a/src/app/_store/raidStore.ts
+++ b/src/app/_store/raidStore.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import { MonstersType, raidList, RaidListType } from "../_constant/raidList";
+
+type State = {
+  raidList: RaidListType[];
+  selectedBoss: MonstersType | null;
+  raidName: string | null;
+};
+
+type Action = {
+  setSelectBoss: (raidName: string, monsterName: string) => void;
+  setRaidName: (raid: string) => void;
+  resetRaid: () => void;
+};
+
+export const useRaidStore = create<State & Action>((set) => {
+  return {
+    raidList: raidList as RaidListType[],
+    selectedBoss: null,
+    raidName: null,
+    setSelectBoss: (raidName, monsterName) => {
+      set((state) => {
+        const selectedRaid = state.raidList.find(
+          (r) => r.raid_name === raidName,
+        );
+        const selectedBoss = selectedRaid?.monsters.find(
+          (m) => m.name === monsterName,
+        );
+        return { selectedBoss };
+      });
+    },
+    resetRaid: () => {
+      set({ selectedBoss: null });
+    },
+    setRaidName: (raid) => {
+      set(() => {
+        return { raidName: raid };
+      });
+    },
+  };
+});


### PR DESCRIPTION
## 상한 계산 기능 추가
-몬스터 상한에 따라 유저의 스텟을 계산해 상한에서 얼만큼 +인지 -인지 계산해주는 기능을 추가

## 개선
- search, reset, dropdown 메뉴를 헤더 컴포넌트로 통합
- table 스타일 flex로 변경 세로로 8줄은 항상 차지하게 변경

